### PR TITLE
update ci so wav-format-check passes

### DIFF
--- a/.github/workflows/wav-format-check.yaml
+++ b/.github/workflows/wav-format-check.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'flags-archive/**'
+
 jobs:
   wav-format-check:
     runs-on: ubuntu-latest
@@ -20,5 +19,15 @@ jobs:
     
     - name: WAV format check
       run: |
+        # Capture the modified files matching the directory path
+        CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')
+
+        # If the variable is empty, skip execution and pass cleanly
+        if [ -z "$CHANGED_FILES" ]; then
+          echo "No files modified in flags-archive/. Skipping validation check."
+          exit 0
+        fi
+
+        # Otherwise, proceed with the original installation and test suite
         sudo apt-get install --no-install-recommends libimage-exiftool-perl -y
-        ./qa/wav-format-check $(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')
+        ./qa/wav-format-check $CHANGED_FILES

--- a/.github/workflows/wav-format-check.yaml
+++ b/.github/workflows/wav-format-check.yaml
@@ -19,15 +19,12 @@ jobs:
     
     - name: WAV format check
       run: |
-        # Capture the modified files matching the directory path
         CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')
 
-        # If the variable is empty, skip execution and pass cleanly
         if [ -z "$CHANGED_FILES" ]; then
           echo "No files modified in flags-archive/. Skipping validation check."
           exit 0
         fi
 
-        # Otherwise, proceed with the original installation and test suite
         sudo apt-get install --no-install-recommends libimage-exiftool-perl -y
         ./qa/wav-format-check $CHANGED_FILES

--- a/.github/workflows/wav-format-check.yaml
+++ b/.github/workflows/wav-format-check.yaml
@@ -19,8 +19,8 @@ jobs:
     
     - name: WAV format check
       run: |
-        CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')
-        if [ -z "$CHANGED_FILES" ]; then
+        CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')"
+        if [ -z "${CHANGED_FILES}" ]; then
           echo "No files modified in flags-archive/. Skipping validation check."
           exit 0
         fi

--- a/.github/workflows/wav-format-check.yaml
+++ b/.github/workflows/wav-format-check.yaml
@@ -20,11 +20,9 @@ jobs:
     - name: WAV format check
       run: |
         CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')
-
         if [ -z "$CHANGED_FILES" ]; then
           echo "No files modified in flags-archive/. Skipping validation check."
           exit 0
         fi
-
         sudo apt-get install --no-install-recommends libimage-exiftool-perl -y
         ./qa/wav-format-check $CHANGED_FILES

--- a/.github/workflows/wav-format-check.yaml
+++ b/.github/workflows/wav-format-check.yaml
@@ -19,10 +19,15 @@ jobs:
     
     - name: WAV format check
       run: |
-        CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep -E '^(flags-archive/)')"
+        CHANGED_FILES="$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }} | grep -E '^(flags-archive/)' || true)"
+
         if [ -z "${CHANGED_FILES}" ]; then
           echo "No files modified in flags-archive/. Skipping validation check."
           exit 0
         fi
+
+        echo "Files to check:"
+        echo "${CHANGED_FILES}"
+
         sudo apt-get install --no-install-recommends libimage-exiftool-perl -y
         ./qa/wav-format-check $CHANGED_FILES

--- a/qa/wav-format-check
+++ b/qa/wav-format-check
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## This tests all the wav files in flags-archive/
+
 if [ ! -x "$(command -v exiftool 2>&1)" ]; then
   printf 'Please install exiftool\n'
   exit 1


### PR DESCRIPTION
When a required check is conditional and the conditional is not met it
blocks the ci pipeline.  Converting this check to always run but bail
out successfully quickly if there are no changes.
